### PR TITLE
Merge next word by common letters

### DIFF
--- a/src/Cipher.hs
+++ b/src/Cipher.hs
@@ -53,9 +53,7 @@ getCipherMaps DecryptOptions{..} = fmap mergeAllCipherMaps . handleMissing . map
     mergeAllCipherMaps cipherMaps =
       let (first', rest) = maxBy (length . fst) cipherMaps
           toLetterBag = first Set.fromList
-          choose _ = \case
-            [] -> error "should not happen"
-            (a:as) -> (a, as)
+          choose (letterBag, _) = maxBy $ \(letterBag', _) -> length $ Set.intersection letterBag letterBag'
           merge (letterBag1, cipherMaps1) (letterBag2, cipherMaps2) =
             (Set.union letterBag1 letterBag2, productMaybe mergeCipherMaps cipherMaps1 cipherMaps2)
       in snd $ foldBy choose merge (toLetterBag first') (map toLetterBag rest)

--- a/src/Cipher.hs
+++ b/src/Cipher.hs
@@ -37,19 +37,19 @@ getCipherMaps DecryptOptions{..} = fmap mergeAllCipherMaps . handleMissing . map
     getCipherMapsWithWord cipherWord = (cipherWord, getCipherMapsForWord cipherWord)
 
     -- handle cipherwords without any CipherMaps
-    handleMissing :: [(String, [CipherMap])] -> DecryptM [[CipherMap]]
+    handleMissing :: [(String, [CipherMap])] -> DecryptM [(String, [CipherMap])]
     handleMissing cipherMaps = if strict
       then case filter (null . snd) cipherMaps of
-        [] -> Right $ map snd cipherMaps
+        [] -> Right cipherMaps
         missingWords -> Left $ MissingWords $ map fst missingWords
-      else Right $ filter (not . null) . map snd $ cipherMaps
+      else Right $ filter (not . null . snd) $ cipherMaps
 
-    mergeAllCipherMaps :: [[CipherMap]] -> [CipherMap]
+    mergeAllCipherMaps :: [(String, [CipherMap])] -> [CipherMap]
     mergeAllCipherMaps [] = []
     mergeAllCipherMaps (first:rest) =
       let choose [] = error "should not happen"
           choose (a:as) = (a, as)
-      in foldBy choose (productMaybe mergeCipherMaps) first rest
+      in foldBy choose (productMaybe mergeCipherMaps) (snd first) (map snd rest)
 
 -- | Fold, except using the given function to choose the next item to fold in.
 -- The input list to the choose function is guaranteed to be non-empty.

--- a/src/Cipher.hs
+++ b/src/Cipher.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Cipher (decrypt) where
@@ -47,8 +48,9 @@ getCipherMaps DecryptOptions{..} = fmap mergeAllCipherMaps . handleMissing . map
     mergeAllCipherMaps :: [(String, [CipherMap])] -> [CipherMap]
     mergeAllCipherMaps [] = []
     mergeAllCipherMaps (first:rest) =
-      let choose _ [] = error "should not happen"
-          choose _ (a:as) = (a, as)
+      let choose _ = \case
+            [] -> error "should not happen"
+            (a:as) -> (a, as)
       in foldBy choose (productMaybe mergeCipherMaps) (snd first) (map snd rest)
 
 -- | Fold, except using the given function to choose the next item to fold in.

--- a/src/Cipher.hs
+++ b/src/Cipher.hs
@@ -47,18 +47,18 @@ getCipherMaps DecryptOptions{..} = fmap mergeAllCipherMaps . handleMissing . map
     mergeAllCipherMaps :: [(String, [CipherMap])] -> [CipherMap]
     mergeAllCipherMaps [] = []
     mergeAllCipherMaps (first:rest) =
-      let choose [] = error "should not happen"
-          choose (a:as) = (a, as)
+      let choose _ [] = error "should not happen"
+          choose _ (a:as) = (a, as)
       in foldBy choose (productMaybe mergeCipherMaps) (snd first) (map snd rest)
 
 -- | Fold, except using the given function to choose the next item to fold in.
 -- The input list to the choose function is guaranteed to be non-empty.
 --
--- > foldBy (\(a:as) -> (a, as)) == foldl
-foldBy :: ([a] -> (a, [a])) -> (b -> a -> b) -> b -> [a] -> b
+-- > foldBy (\_ (a:as) -> (a, as)) == foldl
+foldBy :: (b -> [a] -> (a, [a])) -> (b -> a -> b) -> b -> [a] -> b
 foldBy _ _ b [] = b
 foldBy choose f b as =
-  let (a, as') = choose as
+  let (a, as') = choose b as
       b' = f b a
   in foldBy choose f b' as'
 


### PR DESCRIPTION
Instead of `foldl`, where the next element to fold in is the `head` of the list, choose the next element to fold in by finding the cipherword with the most shared letters with the letters already seen.

Holy cow, got runtime from 21.41 seconds down to 0.5 seconds — 4200% speed up!

[compare.tar.gz](https://github.com/brandonchinn178/cipher/files/3342622/compare.tar.gz)
